### PR TITLE
Add certificates from Let's Encrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *~
-./certs/*.crt
-./certs/*.key
+certs/
+.DS_STORE
+*.pem
+*.key
+*.crt
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 all: up
 
-up: 
+up:
 	docker-compose up -d
 
-clean: 
-	stop 
+clean: stop rm
 
-stop: 
+stop:
 	docker-compose stop
+
+rm:
+	docker-compose rm -vf
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The other services then only need to add three environment variables which will 
 		  - VIRTUAL_HOST=beta-sso.dina-web.net
 		  - LETSENCRYPT_EMAIL=dina@mail.dina-web.net
 
+If you have already certs (wildcard certs for example), you put those in the ./certs directory so those are used instead of letsencrypt-generated certs.
+
+If you need special headers across services, for example for "cors" purposes, add them in `./conf/dina.conf`.
+
 # Good to know
 
 The proxy is a singleton (it binds on and accepts traffic on port 80 and 443 only, re-routing it) so it shouldn't run in multiple instances. Therefore it can have a "global" server-wide container name, such as "proxy". 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,40 @@
 # dw-proxy
-A reverse proxy based on the NGINX Reverse Proxy <br>
-- https://www.nginx.com/resources/admin-guide/reverse-proxy/ <br>
-- https://hub.docker.com/r/jwilder/nginx-proxy/ <br>
-if you are using SSL, put your shared.crt and shared.key in the 'certs'-directory
+
+A reverse proxy based on nginx, capable of automatically fetching, installing and renewing SSL certificates using its `letsencrypt` companion at no cost. So using it saves a lot of manual maintenance steps.
+
+# Usage
+
+Firstly, `docker` and `docker-compose` are required.
+
+Run only one instance of this component on the server to get a reverse proxy with SSL support in front of other services.
+
+The other services then only need to add three environment variables which will route traffic to them. In the `docker-compose.yml` file of the service, add something along these lines to expose it under a specific name with SSL support provided from `dw-proxy`:
+
+		environment:
+		  - VIRTUAL_HOST=beta-sso.dina-web.net
+		  - LETSENCRYPT_HOST=beta-sso.dina-web.net
+		  - LETSENCRYPT_EMAIL=dina@mail.dina-web.net
+
+
+# Good to know
+
+The proxy is a singleton (it binds on and accepts traffic on port 80 and 443 only, re-routing it) so it shouldn't run in multiple instances. Therefore it can have a "global" server-wide container names, here we use "proxy" for nginx and "letsencrypt" for the SSL certificate companion. 
+
+The `docker-compose.yml` file also uses "restart: always" to work around some errors that otherwise will appear due to asynchronous service starts where the companion components needs a file not yet available from the nginx component.
+
+# CLI commands for deploying
+
+
+Then get the code with `git` and run the component with `make`:
+
+		sudo apt-get install make git
+		mkdir -p repos && cd repos
+		git clone <slug-for-this-repo>
+		make
+
+# References
+
+- https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion/
+- https://www.nginx.com/resources/admin-guide/reverse-proxy/
+- https://hub.docker.com/r/jwilder/nginx-proxy/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dw-proxy
 
-A reverse proxy based on nginx, capable of automatically fetching, installing and renewing SSL certificates using its `letsencrypt` companion at no cost. So using it saves a lot of manual maintenance steps.
+A reverse proxy based on `nginx`, capable of automatically fetching, installing and renewing `letsencrypt`SSL certificates at no cost. So using it saves a lot of manual maintenance steps.
 
 # Usage
 
@@ -12,15 +12,13 @@ The other services then only need to add three environment variables which will 
 
 		environment:
 		  - VIRTUAL_HOST=beta-sso.dina-web.net
-		  - LETSENCRYPT_HOST=beta-sso.dina-web.net
 		  - LETSENCRYPT_EMAIL=dina@mail.dina-web.net
-
 
 # Good to know
 
-The proxy is a singleton (it binds on and accepts traffic on port 80 and 443 only, re-routing it) so it shouldn't run in multiple instances. Therefore it can have a "global" server-wide container names, here we use "proxy" for nginx and "letsencrypt" for the SSL certificate companion. 
+The proxy is a singleton (it binds on and accepts traffic on port 80 and 443 only, re-routing it) so it shouldn't run in multiple instances. Therefore it can have a "global" server-wide container name, such as "proxy". 
 
-The `docker-compose.yml` file also uses "restart: always" to work around some errors that otherwise will appear due to asynchronous service starts where the companion components needs a file not yet available from the nginx component.
+The `docker-compose.yml` file also uses "restart: always" to work around some errors may otherwise will appear due to asynchronous service starts where the companion components needs a file not yet available from the nginx component.
 
 # CLI commands for deploying
 
@@ -34,7 +32,7 @@ Then get the code with `git` and run the component with `make`:
 
 # References
 
-- https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion/
+- https://hub.docker.com/r/eforce21/letsencrypt-nginx-proxy/~/dockerfile/
 - https://www.nginx.com/resources/admin-guide/reverse-proxy/
 - https://hub.docker.com/r/jwilder/nginx-proxy/
 

--- a/conf/dina.conf
+++ b/conf/dina.conf
@@ -1,1 +1,1 @@
-add_header Access-Control-Allow-Origin: *.dina-web.net;
+add_header Access-Control-Allow-Origin "*";

--- a/conf/dina.conf
+++ b/conf/dina.conf
@@ -1,0 +1,1 @@
+add_header Access-Control-Allow-Origin: *.dina-web.net;

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -1,1 +1,0 @@
-Access-Control-Allow-Origin: *.dina-web.net

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -1,0 +1,1 @@
+Access-Control-Allow-Origin: *.dina-web.net

--- a/docker-compose.alternative.yml
+++ b/docker-compose.alternative.yml
@@ -1,0 +1,34 @@
+fs:
+  image: tianon/true
+  volumes:
+    - ./certs:/etc/nginx/certs
+
+proxy:
+  image: jwilder/nginx-proxy
+  container_name: proxy
+  restart: always
+  ports:
+    - "80:80"
+    - "443:443"
+  volumes_from:
+    - fs
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ./conf.d:/etc/nginx/conf.d
+    - ./vhost.d:/etc/nginx/vhost.d
+    - ./html:/usr/share/nginx/html
+
+letsencrypt:
+  image: jrcs/letsencrypt-nginx-proxy-companion
+  container_name: letsencrypt
+  restart: always
+  volumes_from:
+    - proxy
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+
+# Remember to set environment variables on new virtualhosts:
+# for example:
+#    - VIRTUAL_HOST=beta-sso.dina-web.net
+#    - LETSENCRYPT_HOST=beta-sso.dina-web.net
+#    - LETSENCRYPT_EMAIL=dina@mail.dina-web.net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 fs:
   image: tianon/true
   volumes:
+    - ./conf:/etc/nginx/conf.d
     - ./certs:/etc/nginx/certs
+    - ./certs-archive:/etc/letsencrypt/archive
 
 proxy:
   image: eforce21/letsencrypt-nginx-proxy
@@ -14,6 +16,6 @@ proxy:
     - /var/run/docker.sock:/tmp/docker.sock:ro
 
 # Remember to set environment variables on new virtualhosts:
-# for example:
+# (the first one is required, the other one is recommended)
 #    - VIRTUAL_HOST=beta-sso.dina-web.net
 #    - LETSENCRYPT_EMAIL=dina@mail.dina-web.net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,34 @@
-nginx-proxy:
+fs:
+  image: tianon/true
+  volumes:
+    - ./certs:/etc/nginx/certs
+
+proxy:
   image: jwilder/nginx-proxy
+  container_name: proxy
+  restart: always
   ports:
     - "80:80"
     - "443:443"
-  volumes:
-    - "/var/run/docker.sock:/tmp/docker.sock:ro"
-    - "./certs:/etc/nginx/certs:ro"
-    - "/etc/nginx/vhost.d"
-    - "/usr/share/nginx/html"
-
-letsencrypt-nginx-proxy-companion:
-  image: jrcs/letsencrypt-nginx-proxy-companion
-  container_name: letsencrypt-nginx-proxy-companion
   volumes_from:
-    - nginx-proxy
+    - fs
   volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock:ro"
-    - "./certs:/etc/nginx/certs:rw"
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ./conf.d:/etc/nginx/conf.d
+    - ./vhost.d:/etc/nginx/vhost.d
+    - ./html:/usr/share/nginx/html
 
+letsencrypt:
+  image: jrcs/letsencrypt-nginx-proxy-companion
+  container_name: letsencrypt
+  restart: always
+  volumes_from:
+    - proxy
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock:ro
 
-# Need to set environment variables on new virtualhosts:
-#    - LETSENCRYPT_TEST=true/false
+# Remember to set environment variables on new virtualhosts:
+# for example:
+#    - VIRTUAL_HOST=beta-sso.dina-web.net
 #    - LETSENCRYPT_HOST=beta-sso.dina-web.net
-#    - LETSENCRYPT_EMAIL=email@example.com
+#    - LETSENCRYPT_EMAIL=dina@mail.dina-web.net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,7 @@ fs:
     - ./certs:/etc/nginx/certs
 
 proxy:
-  image: jwilder/nginx-proxy
-  container_name: proxy
-  restart: always
+  image: eforce21/letsencrypt-nginx-proxy
   ports:
     - "80:80"
     - "443:443"
@@ -14,21 +12,8 @@ proxy:
     - fs
   volumes:
     - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./conf.d:/etc/nginx/conf.d
-    - ./vhost.d:/etc/nginx/vhost.d
-    - ./html:/usr/share/nginx/html
-
-letsencrypt:
-  image: jrcs/letsencrypt-nginx-proxy-companion
-  container_name: letsencrypt
-  restart: always
-  volumes_from:
-    - proxy
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock:ro
 
 # Remember to set environment variables on new virtualhosts:
 # for example:
 #    - VIRTUAL_HOST=beta-sso.dina-web.net
-#    - LETSENCRYPT_HOST=beta-sso.dina-web.net
 #    - LETSENCRYPT_EMAIL=dina@mail.dina-web.net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,22 @@ nginx-proxy:
     - "80:80"
     - "443:443"
   volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs
+    - "/var/run/docker.sock:/tmp/docker.sock:ro"
+    - "./certs:/etc/nginx/certs:ro"
+    - "/etc/nginx/vhost.d"
+    - "/usr/share/nginx/html"
+
+letsencrypt-nginx-proxy-companion:
+  image: jrcs/letsencrypt-nginx-proxy-companion
+  container_name: letsencrypt-nginx-proxy-companion
+  volumes_from:
+    - nginx-proxy
+  volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    - "./certs:/etc/nginx/certs:rw"
+
+
+# Need to set environment variables on new virtualhosts:
+#    - LETSENCRYPT_TEST=true/false
+#    - LETSENCRYPT_HOST=beta-sso.dina-web.net
+#    - LETSENCRYPT_EMAIL=email@example.com


### PR DESCRIPTION
I've started to update the proxy to see if it is possible to use Let's Encrypt. It looks like the [jrcs/letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) docker image is one of the most popular right now.

@mskyttner @Inkimar @idali0226  what do you think? Have you done any more testing on this?
