### PR TITLE
Configurable nginx max body size to allow large posts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM jwilder/nginx-proxy
+RUN { \
+      echo 'server_tokens off;'; \
+      echo 'client_max_body_size 100m;'; \
+    } > /etc/nginx/conf.d/dina_proxy.conf
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 ME=$(USER)
 all: up
 
+build:
+	docker build -t dina/proxy:v0 .
+
+release:
+	docker push -t dina/proxy:v0
+
 clean: stop rm
 
 up:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,12 @@
-nginx-proxy:
+proxy:
   image: jwilder/nginx-proxy
+  environment:
+    - NGINX_MAX_BODY_SZ=100m
   ports:
-    - "80:80"
-    - "443:443"
+    - 80:80
+    - 443:443
   volumes:
     - /var/run/docker.sock:/tmp/docker.sock:ro
     - ./certs:/etc/nginx/certs
+    - ./site.template:/etc/nginx/conf.d/site.template
+  command: /bin/bash -c "envsubst < /etc/nginx/conf.d/site.template > /etc/nginx/conf.d/dina.conf && forego start -r"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 proxy:
-  image: jwilder/nginx-proxy
+  image: dina/proxy:v0
   environment:
     - NGINX_MAX_BODY_SZ=100m
   ports:

--- a/site.template
+++ b/site.template
@@ -1,0 +1,3 @@
+server {
+        client_max_body_size $NGINX_MAX_BODY_SZ;
+}


### PR DESCRIPTION
This is an attempt to address #3 by changing the server wide nginx configuration setting for the reverse proxy in order to allow large posts (for example of big images) through the proxy. 
